### PR TITLE
Add graphviz build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ brew install graphviz
 ```
 - Linux:
 ```
-apt-get install graphviz
+apt-get install graphviz libgraphviz-dev
 ```
 - Other OS(s): https://graphviz.org/download/
 


### PR DESCRIPTION
Adds `libgraphviz-dev` to the linux install instructions. Without it installation fails with `pygraphviz/graphviz_wrap.c:2711:10: fatal error: graphviz/cgraph.h: No such file or directory`.